### PR TITLE
feat(presets): add range slider recipe

### DIFF
--- a/examples/react/astro/src/components/ui/range-slider.tsx
+++ b/examples/react/astro/src/components/ui/range-slider.tsx
@@ -1,12 +1,12 @@
 import * as Ark from '@ark-ui/react/range-slider'
 import { styled } from 'styled-system/jsx'
-import { slider, type SliderVariantProps } from 'styled-system/recipes'
+import { rangeSlider, type RangeSliderVariantProps } from 'styled-system/recipes'
 import { createStyleContext } from '~/lib/create-style-context'
 
-const { withProvider, withContext } = createStyleContext(slider)
+const { withProvider, withContext } = createStyleContext(rangeSlider)
 
 export * from '@ark-ui/react/range-slider'
-export type RangeSliderProps = Ark.RangeSliderProps & SliderVariantProps
+export type RangeSliderProps = Ark.RangeSliderProps & RangeSliderVariantProps
 
 const RangeSliderRoot = withProvider(styled(Ark.RangeSlider.Root), 'root')
 export const RangeSliderControl = withContext(styled(Ark.RangeSlider.Control), 'control')

--- a/examples/react/gatsby/src/components/ui/range-slider.tsx
+++ b/examples/react/gatsby/src/components/ui/range-slider.tsx
@@ -1,12 +1,12 @@
 import * as Ark from '@ark-ui/react/range-slider'
 import { styled } from 'styled-system/jsx'
-import { slider, type SliderVariantProps } from 'styled-system/recipes'
+import { rangeSlider, type RangeSliderVariantProps } from 'styled-system/recipes'
 import { createStyleContext } from '~/lib/create-style-context'
 
-const { withProvider, withContext } = createStyleContext(slider)
+const { withProvider, withContext } = createStyleContext(rangeSlider)
 
 export * from '@ark-ui/react/range-slider'
-export type RangeSliderProps = Ark.RangeSliderProps & SliderVariantProps
+export type RangeSliderProps = Ark.RangeSliderProps & RangeSliderVariantProps
 
 const RangeSliderRoot = withProvider(styled(Ark.RangeSlider.Root), 'root')
 export const RangeSliderControl = withContext(styled(Ark.RangeSlider.Control), 'control')

--- a/examples/react/next-js/src/components/ui/range-slider.tsx
+++ b/examples/react/next-js/src/components/ui/range-slider.tsx
@@ -1,12 +1,12 @@
 import * as Ark from '@ark-ui/react/range-slider'
 import { styled } from 'styled-system/jsx'
-import { slider, type SliderVariantProps } from 'styled-system/recipes'
+import { rangeSlider, type RangeSliderVariantProps } from 'styled-system/recipes'
 import { createStyleContext } from '~/lib/create-style-context'
 
-const { withProvider, withContext } = createStyleContext(slider)
+const { withProvider, withContext } = createStyleContext(rangeSlider)
 
 export * from '@ark-ui/react/range-slider'
-export type RangeSliderProps = Ark.RangeSliderProps & SliderVariantProps
+export type RangeSliderProps = Ark.RangeSliderProps & RangeSliderVariantProps
 
 const RangeSliderRoot = withProvider(styled(Ark.RangeSlider.Root), 'root')
 export const RangeSliderControl = withContext(styled(Ark.RangeSlider.Control), 'control')

--- a/packages/cli/components.json
+++ b/packages/cli/components.json
@@ -272,7 +272,7 @@
     },
     "isArkComponent": true,
     "rootComponent": "RangeSlider",
-    "className": "slider"
+    "className": "range-slider"
   },
   "rating-group": {
     "components": {

--- a/packages/cli/src/generate-component.ts
+++ b/packages/cli/src/generate-component.ts
@@ -29,7 +29,6 @@ export const generateComponent = async (moduleName: string) => {
       rootComponent: pascalCase(moduleName),
       className: match(moduleName)
         .with('switch', () => 'switchRecipe') // resvered word
-        .with('range-slider', () => 'slider') // same recipe
         .otherwise(() => camelCase(moduleName)),
     },
   }

--- a/packages/presets/src/theme/recipes/index.ts
+++ b/packages/presets/src/theme/recipes/index.ts
@@ -23,6 +23,7 @@ import { pinInput } from './pin-input'
 import { popover } from './popover'
 import { radioButtonGroup } from './radio-button-group'
 import { radioGroup } from './radio-group'
+import { rangeSlider } from './range-slider'
 import { ratingGroup } from './rating-group'
 import { segmentGroup } from './segment-group'
 import { select } from './select'
@@ -64,6 +65,7 @@ export const slotRecipes = {
   pinInput,
   popover,
   radioGroup,
+  rangeSlider,
   radioButtonGroup,
   ratingGroup,
   segmentGroup,

--- a/packages/presets/src/theme/recipes/range-slider.ts
+++ b/packages/presets/src/theme/recipes/range-slider.ts
@@ -1,0 +1,68 @@
+import { rangeSliderAnatomy } from '@ark-ui/react'
+import { defineSlotRecipe } from '@pandacss/dev'
+
+export const rangeSlider = defineSlotRecipe({
+  className: 'range-slider',
+  description: 'A range slider style',
+  slots: rangeSliderAnatomy.keys(),
+  base: {
+    root: {
+      width: 'full',
+    },
+    control: {
+      position: 'relative',
+      display: 'flex',
+      alignItems: 'center',
+    },
+    track: {
+      backgroundColor: 'bg.muted',
+      borderRadius: 'l2',
+      flex: '1',
+    },
+    range: {
+      background: 'accent.default',
+      borderRadius: 'l2',
+    },
+    thumb: {
+      background: 'bg.default',
+      borderColor: 'border.accent',
+      borderRadius: 'full',
+      borderWidth: '2px',
+      boxShadow: 'sm',
+      outline: 'none',
+    },
+    label: {
+      color: 'fg.emphasized',
+      fontWeight: 'semibold',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+  },
+  variants: {
+    size: {
+      md: {
+        control: {
+          py: '2',
+        },
+        range: {
+          height: '2',
+        },
+        track: {
+          height: '2',
+        },
+        thumb: {
+          height: '6',
+          width: '6',
+        },
+        marker: {
+          mt: '2',
+          textStyle: 'sm',
+        },
+        label: {
+          textStyle: 'sm',
+        },
+      },
+    },
+  },
+})

--- a/website/src/components/ui/range-slider.tsx
+++ b/website/src/components/ui/range-slider.tsx
@@ -1,12 +1,12 @@
 import * as Ark from '@ark-ui/react/range-slider'
 import { styled } from 'styled-system/jsx'
-import { slider, type SliderVariantProps } from 'styled-system/recipes'
+import { rangeSlider, type RangeSliderVariantProps } from 'styled-system/recipes'
 import { createStyleContext } from '~/lib/create-style-context'
 
-const { withProvider, withContext } = createStyleContext(slider)
+const { withProvider, withContext } = createStyleContext(rangeSlider)
 
 export * from '@ark-ui/react/range-slider'
-export type RangeSliderProps = Ark.RangeSliderProps & SliderVariantProps
+export type RangeSliderProps = Ark.RangeSliderProps & RangeSliderVariantProps
 
 const RangeSliderRoot = withProvider(styled(Ark.RangeSlider.Root), 'root')
 export const RangeSliderControl = withContext(styled(Ark.RangeSlider.Control), 'control')

--- a/website/src/lib/find-component.ts
+++ b/website/src/lib/find-component.ts
@@ -28,7 +28,6 @@ export const findComponent = async (name: string): Promise<Component | undefined
 
   const recipeName = match(name)
     .with('icon-button', () => 'button')
-    .with('range-slider', () => 'slider')
     .otherwise(() => name)
 
   if (entry) {


### PR DESCRIPTION
I address this pull request to ensure consistency within components and fix a bug.

The problem I encountered is using the `RangeSlider` component with `Slider` recipe. In this case, we have `RangeSlider` component with `data-scope` set to `range-slider`, but our `Slider` recipe works only with `slider` `data-scope`. I think it could lead to misunderstanding that nearly all Ark components are distinct but one not.

For example, check [Ark UI documentation](https://ark-ui.com/docs/react/components/range-slider/usage) and chakra-ui/ark#1286
