### PR TITLE
fix(date-picker): resolve modal not fitting content in desktop view

### DIFF
--- a/packages/presets/src/theme/recipes/date-picker.ts
+++ b/packages/presets/src/theme/recipes/date-picker.ts
@@ -29,6 +29,7 @@ export const datePicker = defineSlotRecipe({
       borderRadius: 'l3',
       borderWidth: '1px',
       p: '4',
+      width: 'fit-content',
     },
     grid: {
       display: 'flex',


### PR DESCRIPTION
This resolves the content overflow in the desktop layout,
on mobile the positioning/size of the modal should be adjusted, but this is out of scope for the issue I'm resolving.

closes #14

<img width="384" alt="image" src="https://github.com/cschroeter/park-ui/assets/6171622/a733e616-e3ff-4d50-843b-96729be337a9">
