### PR TITLE
Semantic code tag

### DIFF
--- a/packages/presets/src/theme/recipes/code.ts
+++ b/packages/presets/src/theme/recipes/code.ts
@@ -2,7 +2,7 @@ import { defineRecipe } from '@pandacss/dev'
 
 export const code = defineRecipe({
   className: 'code',
-  description: 'An code style',
+  description: 'A code style',
   base: {
     alignItems: 'center',
     bg: 'bg.subtle',

--- a/website/src/components/ui/code.tsx
+++ b/website/src/components/ui/code.tsx
@@ -4,4 +4,4 @@ import { styled } from 'styled-system/jsx'
 import { code, type CodeVariantProps } from 'styled-system/recipes'
 
 export type CodeProps = CodeVariantProps & ComponentPropsWithoutRef<typeof ark.code>
-export const Code = styled(ark.div, code)
+export const Code = styled(ark.code, code)


### PR DESCRIPTION
## Description

- Changed `Code` component to wrap `ark.code` instead of `ark.div` for semantic HTML
- Fixed minor typo in code recipe