### PR TITLE
docs: Add content to tabs in tabs.demo.tsx

### DIFF
--- a/website/src/components/demos/tabs.demo.tsx
+++ b/website/src/components/demos/tabs.demo.tsx
@@ -18,10 +18,10 @@ export const Demo = (props: TabsProps) => {
         ))}
         <Tabs.Indicator />
       </Tabs.List>
-      <Tabs.Content value="react">&nbsp;</Tabs.Content>
-      <Tabs.Content value="solid">&nbsp;</Tabs.Content>
-      <Tabs.Content value="svelte">&nbsp;</Tabs.Content>
-      <Tabs.Content value="vue">&nbsp;</Tabs.Content>
+      <Tabs.Content value="react">Know React? Check out Solid!</Tabs.Content>
+      <Tabs.Content value="solid">Know Solid? Check out Svelte!</Tabs.Content>
+      <Tabs.Content value="svelte">Know Svelte? Check out Vue!</Tabs.Content>
+      <Tabs.Content value="vue">Know Vue? Check out React!</Tabs.Content>
     </Tabs.Root>
   )
 }


### PR DESCRIPTION
Currently the tabs demo looks identical to a horizontal [segment group](https://park-ui.com/docs/panda/components/segment-group)