### PR TITLE
fix(avatar): fallback element border

### DIFF
--- a/components/react/panda.config.ts
+++ b/components/react/panda.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from '@pandacss/dev'
+import { createPreset } from '@park-ui/panda-preset'
 
 export default defineConfig({
   preflight: true,
-  presets: ['@pandacss/preset-base', '@park-ui/panda-preset'],
+  presets: ['@pandacss/preset-base', createPreset()],
   include: ['./src/**/*.{js,jsx,ts,tsx}'],
   jsxFramework: 'react',
   outdir: 'styled-system',

--- a/plugins/panda/CHANGELOG.md
+++ b/plugins/panda/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Renamed `placement` prop to `variant` in `Drawer` component for better consistency with other CSS frameworks.
 - Renamed `Label` to `FormLabel`
 
+### Fixed
+
+- Resolved an issue that `Avatar` did not render correctly when no image was provided.
+
 ## [0.27.0] - 2023-12-19
 
 ### Added
@@ -21,7 +25,7 @@
 
 - Declared `@pandacss/dev` and `@pandacss/types` as peer dependencies to avoid TypeScript errors.
 
-### Changed 
+### Changed
 
 - Updated import paths for more precise module referencing to help with tree-shaking.
 
@@ -31,7 +35,6 @@ import { Avatar as ArkAvatar } from '@ark-ui/react'
 // after
 import { Avatar as ArkAvatar } from '@ark-ui/react/avatar'
 ```
-
 
 ## [0.26.1] - 2023-12-14
 

--- a/plugins/panda/src/theme/recipes/avatar.ts
+++ b/plugins/panda/src/theme/recipes/avatar.ts
@@ -17,6 +17,9 @@ export const avatar = defineSlotRecipe({
       fontWeight: 'semibold',
       height: 'inherit',
       justifyContent: 'center',
+      _hidden: {
+        display: 'none',
+      },
     },
     image: {
       objectFit: 'cover',
@@ -32,12 +35,20 @@ export const avatar = defineSlotRecipe({
           height: '8',
           width: '8',
         },
+        image: {
+          height: '8',
+          width: '8',
+        },
         fallback: {
           textStyle: 'xs',
         },
       },
       sm: {
         root: {
+          height: '9',
+          width: '9',
+        },
+        image: {
           height: '9',
           width: '9',
         },
@@ -50,12 +61,20 @@ export const avatar = defineSlotRecipe({
           height: '10',
           width: '10',
         },
+        image: {
+          height: '10',
+          width: '10',
+        },
         fallback: {
           textStyle: 'md',
         },
       },
       lg: {
         root: {
+          height: '11',
+          width: '11',
+        },
+        image: {
           height: '11',
           width: '11',
         },
@@ -68,12 +87,20 @@ export const avatar = defineSlotRecipe({
           height: '12',
           width: '12',
         },
+        image: {
+          height: '12',
+          width: '12',
+        },
         fallback: {
           textStyle: 'xl',
         },
       },
       '2xl': {
         root: {
+          height: '16',
+          width: '16',
+        },
+        image: {
           height: '16',
           width: '16',
         },

--- a/plugins/panda/src/theme/recipes/avatar.ts
+++ b/plugins/panda/src/theme/recipes/avatar.ts
@@ -13,7 +13,6 @@ export const avatar = defineSlotRecipe({
     fallback: {
       alignItems: 'center',
       background: 'bg.subtle',
-      borderWidth: '1px',
       display: 'flex',
       fontWeight: 'semibold',
       height: 'inherit',

--- a/website/src/content/overview/panda/changelog.mdx
+++ b/website/src/content/overview/panda/changelog.mdx
@@ -11,6 +11,10 @@ description: All notable changes to this project will be documented in this file
 - Renamed `placement` prop to `variant` in `Drawer` component for better consistency with other CSS frameworks.
 - Renamed `Label` to `FormLabel`
 
+### Fixed
+
+- Resolved an issue that `Avatar` did not render correctly when no image was provided.
+
 ## [0.27.0] - 2023-12-19
 
 ### Added
@@ -27,7 +31,7 @@ description: All notable changes to this project will be documented in this file
 
 - Declared `@pandacss/dev` and `@pandacss/types` as peer dependencies to avoid TypeScript errors.
 
-### Changed 
+### Changed
 
 - Updated import paths for more precise module referencing to help with tree-shaking.
 
@@ -49,7 +53,8 @@ import { Avatar as ArkAvatar } from '@ark-ui/react/avatar'
 ### Changed
 
 - Integrated latest version of Ark UI 1.2.0
-- Due to an issue with [Next.js](https://github.com/vercel/next.js/issues/51593) and React Server Components, we've revised the export method for multi-part components.
+- Due to an issue with [Next.js](https://github.com/vercel/next.js/issues/51593) and React Server Components, we've
+  revised the export method for multi-part components.
 
 ```tsx
 // before


### PR DESCRIPTION
before & after: 
<img width="380" align="left"  alt="截屏2024-01-01 17 00 37" src="https://github.com/cschroeter/park-ui/assets/82451257/bbccfe04-9ebc-414a-965a-856223d5f2ae">
<img width="360" alt="截屏2024-01-01 17 01 05" src="https://github.com/cschroeter/park-ui/assets/82451257/105dee74-1ab0-4bb6-830a-6d20d83d0c76">

---

And I found there is an error caused by ark-ui.

<img width="788" alt="截屏2024-01-01 17 01 16" src="https://github.com/cschroeter/park-ui/assets/82451257/12bba0bb-9beb-4f21-842d-e458da455146">
