### PR TITLE
feat(website): add jsx framework select

### DIFF
--- a/plugins/panda/src/index.ts
+++ b/plugins/panda/src/index.ts
@@ -12,9 +12,11 @@ import {
   accentColors,
   borderRadii,
   grayColors,
+  jsxFrameworks,
   type AccentColor,
   type BorderRadius,
   type GrayColor,
+  type JSXFramework,
   type PresetOptions,
 } from './types'
 
@@ -47,5 +49,12 @@ const createPreset = (options: PresetOptions = defaultOptions): Preset => {
 
 const defaultPreset = createPreset()
 
-export { accentColors, borderRadii, createPreset, defaultPreset as default, grayColors }
-export type { AccentColor, BorderRadius, GrayColor, PresetOptions }
+export {
+  accentColors,
+  borderRadii,
+  createPreset,
+  defaultPreset as default,
+  grayColors,
+  jsxFrameworks,
+}
+export type { AccentColor, BorderRadius, GrayColor, JSXFramework, PresetOptions }

--- a/plugins/panda/src/types.ts
+++ b/plugins/panda/src/types.ts
@@ -48,3 +48,6 @@ export const accentColors = [
 
 export type GrayColor = (typeof grayColors)[number]
 export const grayColors = ['neutral', 'mauve', 'olive', 'sage', 'sand', 'slate'] as const
+
+export type JSXFramework = (typeof jsxFrameworks)[number]
+export const jsxFrameworks = ['React', 'Solid', 'Vue'] as const

--- a/website/src/components/theme/jsx-framework-select.tsx
+++ b/website/src/components/theme/jsx-framework-select.tsx
@@ -1,0 +1,38 @@
+import { CheckIcon, ChevronsUpDownIcon } from 'lucide-react'
+import { Select } from '~/components/ui'
+import { useThemeGenerator } from '~/lib/use-theme-generator'
+
+export const JsxFrameworkSelect = () => {
+  const { currentJsxFramework, jsxFrameworks, updateJsxFramework } = useThemeGenerator()
+
+  return (
+    <Select.Root
+      items={jsxFrameworks}
+      value={[currentJsxFramework]}
+      // @ts-expect-error
+      onValueChange={(e) => updateJsxFramework(e.items[0])}
+      positioning={{ sameWidth: true }}
+      size="sm"
+    >
+      <Select.Label>JSX Framework</Select.Label>
+      <Select.Control>
+        <Select.Trigger>
+          <Select.ValueText />
+          <ChevronsUpDownIcon />
+        </Select.Trigger>
+      </Select.Control>
+      <Select.Positioner>
+        <Select.Content>
+          {jsxFrameworks.map((jsxFramework, id) => (
+            <Select.Item key={id} item={jsxFramework}>
+              <Select.ItemText>{jsxFramework}</Select.ItemText>
+              <Select.ItemIndicator>
+                <CheckIcon />
+              </Select.ItemIndicator>
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Positioner>
+    </Select.Root>
+  )
+}

--- a/website/src/components/theme/theme-config-dialog.tsx
+++ b/website/src/components/theme/theme-config-dialog.tsx
@@ -10,8 +10,14 @@ interface Props {
 }
 
 export const ThemeConfigDialog = (props: Props) => {
-  const { currentAccentColor, currentGrayColor, currentBorderRadius, pandaConfig, tailwindConfig } =
-    useThemeGenerator()
+  const {
+    currentAccentColor,
+    currentGrayColor,
+    currentBorderRadius,
+    currentJsxFramework,
+    pandaConfig,
+    tailwindConfig,
+  } = useThemeGenerator()
 
   return (
     <Dialog.Root>
@@ -39,7 +45,8 @@ export const ThemeConfigDialog = (props: Props) => {
                     code: pandaConfig
                       .replace('__ACCENT_COLOR__', currentAccentColor)
                       .replace('__GRAY_COLOR__', currentGrayColor)
-                      .replace('__BORDER_RADIUS__', currentBorderRadius),
+                      .replace('__BORDER_RADIUS__', currentBorderRadius)
+                      .replace('__JSX_FRAMEWORK__', currentJsxFramework.toLowerCase()),
                     children: (
                       <div
                         dangerouslySetInnerHTML={{
@@ -47,7 +54,8 @@ export const ThemeConfigDialog = (props: Props) => {
                           __html: props.panda.props.value
                             .replace('__ACCENT_COLOR__', currentAccentColor)
                             .replace('__GRAY_COLOR__', currentGrayColor)
-                            .replace('__BORDER_RADIUS__', currentBorderRadius),
+                            .replace('__BORDER_RADIUS__', currentBorderRadius)
+                            .replace('__JSX_FRAMEWORK__', currentJsxFramework.toLowerCase()),
                         }}
                       />
                     ),

--- a/website/src/components/theme/theme-drawer.tsx
+++ b/website/src/components/theme/theme-drawer.tsx
@@ -7,6 +7,7 @@ import { AccentColorPicker } from './accent-color-picker'
 import { BorderRadiusSlider } from './border-radius-slider'
 import { FontFamilySelect } from './font-family-select'
 import { GrayColorPicker } from './gray-color-picker'
+import { JsxFrameworkSelect } from './jsx-framework-select'
 import { ThemeConfigDialog } from './theme-config-dialog'
 
 interface Props {
@@ -48,6 +49,7 @@ export const ThemeDrawer = (props: PropsWithChildren<Props>) => {
           </Drawer.Header>
           <Drawer.Body>
             <Stack flex="1" gap="5">
+              <JsxFrameworkSelect />
               <FontFamilySelect />
               <GrayColorPicker />
               <AccentColorPicker />

--- a/website/src/lib/use-theme-generator.ts
+++ b/website/src/lib/use-theme-generator.ts
@@ -2,6 +2,7 @@ import {
   accentColors,
   borderRadii,
   grayColors,
+  jsxFrameworks,
   type AccentColor,
   type BorderRadius,
   type GrayColor,
@@ -16,11 +17,13 @@ export const useThemeGenerator = () => {
   const currentGrayColor = useThemeStore((state) => state.grayColor)
   const currentFontFamily = useThemeStore((state) => state.fontFamily)
   const currentBorderRadius = useThemeStore((state) => state.borderRadius)
+  const currentJsxFramework = useThemeStore((state) => state.jsxFramework)
 
   const updateAccentColor = useThemeStore((state) => state.setAccentColor)
   const updateGrayColor = useThemeStore((state) => state.setGrayColor)
   const updateFontFamily = useThemeStore((state) => state.setFontFamily)
   const updateBorderRadius = useThemeStore((state) => state.setBorderRadius)
+  const updateJsxFramework = useThemeStore((state) => state.setJsxFramework)
 
   const reset = useThemeStore((state) => state.reset)
 
@@ -40,21 +43,28 @@ export const useThemeGenerator = () => {
     syncBorderRaius(currentBorderRadius)
   }, [currentBorderRadius])
 
+  useEffect(() => {
+    updateJsxFramework(currentJsxFramework)
+  }, [currentJsxFramework])
+
   return {
     accentColors,
     borderRadii,
     fontFamilies,
     grayColors,
+    jsxFrameworks,
     pandaConfig,
     tailwindConfig,
     currentAccentColor,
     currentBorderRadius,
     currentFontFamily,
     currentGrayColor,
+    currentJsxFramework,
     updateAccentColor,
     updateGrayColor,
     updateFontFamily,
     updateBorderRadius,
+    updateJsxFramework,
     reset,
   }
 }
@@ -205,7 +215,7 @@ export default defineConfig({
     }),
   ],
   include: ['./src/**/*.{js,jsx,ts,tsx}'],
-  jsxFramework: 'react',
+  jsxFramework: '__JSX_FRAMEWORK__',
   outdir: 'styled-system',
 })
 `

--- a/website/src/lib/use-theme-store.ts
+++ b/website/src/lib/use-theme-store.ts
@@ -1,4 +1,4 @@
-import type { AccentColor, BorderRadius, GrayColor } from '@park-ui/panda-preset'
+import type { AccentColor, BorderRadius, GrayColor, JSXFramework } from '@park-ui/panda-preset'
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import type { FontFamily } from './use-theme-generator'
@@ -8,6 +8,7 @@ type State = {
   borderRadius: BorderRadius
   fontFamily: FontFamily
   grayColor: GrayColor
+  jsxFramework: JSXFramework
 }
 
 type Actions = {
@@ -15,6 +16,7 @@ type Actions = {
   setGrayColor: (color: GrayColor) => void
   setFontFamily: (font: FontFamily) => void
   setBorderRadius: (radius: BorderRadius) => void
+  setJsxFramework: (jsxFramework: JSXFramework) => void
   reset: () => void
 }
 
@@ -23,6 +25,7 @@ const initialState: State = {
   borderRadius: 'sm',
   fontFamily: { label: 'Jakarta', value: 'var(--font-jakarta)' },
   grayColor: 'neutral',
+  jsxFramework: 'React',
 }
 
 export const useThemeStore = create<State & Actions>()(
@@ -34,6 +37,7 @@ export const useThemeStore = create<State & Actions>()(
         setBorderRadius: (borderRadius) => set(() => ({ borderRadius })),
         setFontFamily: (fontFamily) => set(() => ({ fontFamily })),
         setGrayColor: (grayColor) => set(() => ({ grayColor })),
+        setJsxFramework: (jsxFramework) => set(() => ({ jsxFramework })),
         reset: () => {
           set(initialState)
         },


### PR DESCRIPTION
## Current
The current preset generator doesn't consider different JSX frameworks.
However, correct examples are shown in the 3rd step in the [getting started guide](https://park-ui.com/docs/panda/overview/getting-started).

## Update
### New behavior
![image](https://github.com/cschroeter/park-ui/assets/6079265/f1404578-ebdb-451e-b6b7-0f6af267b510)

### New look
![image](https://github.com/cschroeter/park-ui/assets/6079265/5faf055d-0149-49cc-8035-e0ce1954adbb)
