### PR TITLE
fix(website): sidebar style

### DIFF
--- a/website/src/layouts/layout.recipe.ts
+++ b/website/src/layouts/layout.recipe.ts
@@ -22,8 +22,8 @@ export const layout = sva({
       overflow: 'auto',
       position: 'fixed',
       px: { base: '4', md: '6' },
-      py: '10',
-      top: '16',
+      py: '6',
+      top: '20',
       width: '64',
     },
     main: {


### PR DESCRIPTION
before: 

![image](https://github.com/cschroeter/park-ui/assets/82451257/99b122e6-c061-4cd7-8a04-b109e4cb712c)

after:

![image](https://github.com/cschroeter/park-ui/assets/82451257/822190ab-12d2-4472-ab6c-5f460c3fb84a)
