### PR TITLE
fix(editable): add style for input

### DIFF
--- a/plugins/panda/src/theme/recipes/editable.ts
+++ b/plugins/panda/src/theme/recipes/editable.ts
@@ -15,5 +15,28 @@ export const editable = defineSlotRecipe({
       display: 'flex',
       gap: '2',
     },
+    input: {
+      appearance: 'none',
+      background: 'none',
+      borderColor: 'border.default',
+      borderRadius: 'l2',
+      borderWidth: '1px',
+      colorPalette: 'accent',
+      color: 'fg.default',
+      outline: 0,
+      position: 'relative',
+      transitionDuration: 'normal',
+      transitionProperty: 'box-shadow, border-color',
+      transitionTimingFunction: 'default',
+      width: 'full',
+      _disabled: {
+        opacity: 0.4,
+        cursor: 'not-allowed',
+      },
+      _focus: {
+        borderColor: 'colorPalette.default',
+        boxShadow: '0 0 0 1px var(--colors-color-palette-default)',
+      },
+    },
   },
 })


### PR DESCRIPTION
before:

<img src="https://github.com/cschroeter/park-ui/assets/82451257/174cac48-9548-4507-9f5c-98bb2fb44d50" width="50%" />

after:
<img src="https://github.com/cschroeter/park-ui/assets/82451257/658a25ad-343b-45fd-9189-3c6768d0d39b" width="50%" />
