### PR TITLE
fix(segment-group): indicator on top of the item

### DIFF
--- a/plugins/panda/src/theme/recipes/segment-group.ts
+++ b/plugins/panda/src/theme/recipes/segment-group.ts
@@ -27,6 +27,7 @@ export const segmentGroup = defineSlotRecipe({
     indicator: {
       borderColor: 'colorPalette.default',
       _horizontal: {
+        bottom: '0',
         borderBottomWidth: '2px',
         transform: 'translateY(1px)',
         width: 'var(--width)',


### PR DESCRIPTION
close: #191 

![image](https://github.com/cschroeter/park-ui/assets/82451257/788e7ec3-c21b-4179-9387-9bbc98232238)
