### PR TITLE
fix(avatar): remove border width

### DIFF
--- a/plugins/panda/src/theme/recipes/avatar.ts
+++ b/plugins/panda/src/theme/recipes/avatar.ts
@@ -7,7 +7,6 @@ export const avatar = defineSlotRecipe({
   base: {
     root: {
       borderRadius: 'full',
-      borderWidth: '1px',
       flexShrink: 0,
     },
     fallback: {


### PR DESCRIPTION
when `avatar` has border-width attribute, it cause `fallback` content isn't centered. 

https://github.com/cschroeter/park-ui/assets/82451257/169bb493-824b-40a5-95e8-ad715c980ecc
