### PR TITLE
Adjust order of properties

### DIFF
--- a/components/panda/react/src/components/ui/pagination.tsx
+++ b/components/panda/react/src/components/ui/pagination.tsx
@@ -19,9 +19,9 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>((props, ref) 
 
   return (
     <ArkPagination.Root
-      ref={ref}
       // @ts-expect-error TODO cssProps is to complex to be typed
       className={cx(styles.root, css(cssProps), className)}
+      ref={ref}
       {...rootProps}
     >
       {({ pages }) => (

--- a/components/panda/react/src/components/ui/pin-input.tsx
+++ b/components/panda/react/src/components/ui/pin-input.tsx
@@ -25,9 +25,9 @@ export const PinInput = forwardRef<HTMLDivElement, PinInputProps>((props, ref) =
 
   return (
     <ArkPinInput.Root
-      ref={ref}
       // @ts-expect-error TODO cssProps is to complex to be typed
       className={cx(styles.root, css(cssProps), className)}
+      ref={ref}
       {...rootProps}
     >
       {children && <ArkPinInput.Label className={styles.label}>{children}</ArkPinInput.Label>}


### PR DESCRIPTION
A very minor patch, but my style guide requires that components properties are sorted alphabetically. Because these two are not, I need to patch my components every time I re-generate Panda components.