### PR TITLE
fix(tree-view): avoid highlighting ::before in first depth when selected

### DIFF
--- a/plugins/panda/src/theme/recipes/tree-view.ts
+++ b/plugins/panda/src/theme/recipes/tree-view.ts
@@ -80,6 +80,11 @@ export const treeView = defineSlotRecipe({
         ps: '6',
         fontWeight: 'semibold',
         color: 'fg.default',
+        _selected: {
+          _before: {
+            bg: 'transparent',
+          },
+        },
       },
       _hover: {
         background: 'gray.a2',


### PR DESCRIPTION
before:
<img width="775" alt="截屏2024-02-29 14 21 35" src="https://github.com/cschroeter/park-ui/assets/82451257/7af661a2-0880-40f5-a0aa-fe0c44184598">

after:
![image](https://github.com/cschroeter/park-ui/assets/82451257/ebb943cf-76ce-4354-9252-21c4100ec99b)
