### PR TITLE
fix(select): style trigger as disabled when select is disabled

### DIFF
--- a/plugins/panda/src/theme/recipes/select.ts
+++ b/plugins/panda/src/theme/recipes/select.ts
@@ -92,6 +92,13 @@ export const select = defineSlotRecipe({
       _placeholderShown: {
         color: 'fg.subtle',
       },
+      _disabled: {
+        color: 'fg.disabled',
+        cursor: 'not-allowed',
+        '& :where(svg)': {
+          color: 'fg.disabled',
+        },
+      },
       '& :where(svg)': {
         color: 'fg.subtle',
       },


### PR DESCRIPTION
This change resolves the issue I just opened https://github.com/cschroeter/park-ui/issues/257. It styles the select trigger to look disabled. 

Before:
<img width="465" alt="Screenshot 2024-03-05 at 12 51 25 PM" src="https://github.com/cschroeter/park-ui/assets/374289/4b18d511-be13-41ab-83eb-2ff505a0fc1d">

After:  
<img width="463" alt="Screenshot 2024-03-05 at 12 56 04 PM" src="https://github.com/cschroeter/park-ui/assets/374289/6ed7521c-1203-4cf2-8a1d-ee5e113b4ae6">
