### PR TITLE
fix(number-input): remove extra border of the input element

### DIFF
--- a/plugins/panda/src/theme/recipes/number-input.ts
+++ b/plugins/panda/src/theme/recipes/number-input.ts
@@ -58,6 +58,7 @@ export const numberInput = defineSlotRecipe({
       },
     },
     input: {
+      border: 'none',
       outline: 'none',
       background: 'transparent',
       width: 'full',


### PR DESCRIPTION
remove the extra border style of the input element in number input element.

before:
![image](https://github.com/cschroeter/park-ui/assets/10807119/91bc76f8-6317-4071-a7b0-666fd4954314)

after:
![image](https://github.com/cschroeter/park-ui/assets/10807119/37bebe88-c4a4-450a-8e4c-0f0a55e0e7ac)
