### PR TITLE
fix(radio-group): add focus-visible styling

### DIFF
--- a/plugins/chakra/src/theme/components/radio-group.ts
+++ b/plugins/chakra/src/theme/components/radio-group.ts
@@ -37,6 +37,14 @@ export const RadioGroup = defineMultiStyleConfig({
         color: 'fg.disabled',
         _hover: { bg: 'initial', color: 'fg.disabled' },
       },
+      '&:has(+ :focus-visible)': {
+        borderColor: 'border.outline',
+        boxShadow: '0 0 0 1px var(--chakra-colors-border-outline)',
+        _checked: {
+          borderColor: `${props.colorScheme}.default`,
+          boxShadow: '0 0 0 1px var(--chakra-colors-accent-default)',
+        },
+      },
     },
     item: {
       alignItems: 'center',

--- a/plugins/panda/src/theme/recipes/radio-group.ts
+++ b/plugins/panda/src/theme/recipes/radio-group.ts
@@ -41,6 +41,14 @@ export const radioGroup = defineSlotRecipe({
           color: 'fg.disabled',
         },
       },
+      '&:has(+ :focus-visible)': {
+        borderColor: 'border.outline',
+        boxShadow: '0 0 0 1px var(--colors-border-outline)',
+        _checked: {
+          borderColor: 'colorPalette.default',
+          boxShadow: '0 0 0 1px var(--colors-color-palette-default)',
+        },
+      },
     },
     item: {
       alignItems: 'center',


### PR DESCRIPTION
## Changes Made
I modified the styling in the Radio Group component to indicate the current position using `focus-visible` with tab controls.

## Motivation
For other major form elements such as Input, Select, Textarea, Checkbox, and Button, styles are applied when `focus-visible` is active. However, this wasn't the case for Radio Group, so I decided to apply the styles there as well.

## Points to Note
In Checkbox and Button elements, the styling used `outline` to surround the component from the outside. However, in Radio, `outline` was already used for styling when checked, so I opted to use `box-shadow` similar to Input and Select, emphasizing just outside the border for styling.

## Screenshots
When focused (selected)
![focus-with-select](https://github.com/cschroeter/park-ui/assets/5827715/067e2825-cb9f-4920-a08b-7b72ae27a9d1)

When focused (unselected)
![focus-without-select](https://github.com/cschroeter/park-ui/assets/5827715/74446a48-7ac9-44ef-95ef-c2436e2a1f34)

When not focused
![not-focus](https://github.com/cschroeter/park-ui/assets/5827715/52eab71d-b299-4aea-9556-e76d8ed399a3)
