### PR TITLE
fix: use inline script in head to avoid FOUC

### DIFF
--- a/website/src/layouts/layout.astro
+++ b/website/src/layouts/layout.astro
@@ -55,10 +55,9 @@ const { title, description } = Astro.props
     <!-- Tracking -->
     <script defer data-domain="park-ui.com" src="https://plausible.io/js/script.js"></script>
     <ViewTransitions />
-  </head>
-  <body>
-    <slot />
-    <script>
+
+    <!-- Inlined to avoid FOUC. -->
+    <script is:inline>
       const setColorMode = () => {
         // @ts-expect-error
         if (JSON.parse(window.localStorage.getItem('park-ui-color-mode')) === 'dark') {
@@ -68,5 +67,8 @@ const { title, description } = Astro.props
       setColorMode()
       document.addEventListener('astro:after-swap', setColorMode)
     </script>
+  </head>
+  <body>
+    <slot />
   </body>
 </html>


### PR DESCRIPTION
use inline script in head tag to avoid color theme FOUC.
![CleanShot 2024-05-11 at 01 31 47](https://github.com/cschroeter/park-ui/assets/36906371/5cf6cfb1-b3e5-4e03-a505-169e3415389c)
