### PR TITLE
[fix][solid][checkbox]: added missing hidden input as per Ark officia…

### DIFF
--- a/components/solid/src/components/ui/checkbox.tsx
+++ b/components/solid/src/components/ui/checkbox.tsx
@@ -29,6 +29,7 @@ export const Checkbox = (props: CheckboxProps) => {
       <Show when={getChildren()}>
         <ArkCheckbox.Label class={styles.label}>{getChildren()}</ArkCheckbox.Label>
       </Show>
+      <ArkCheckbox.HiddenInput />
     </ArkCheckbox.Root>
   )
 }


### PR DESCRIPTION
The current implementation of the checkbox is the following :

```
<ArkCheckbox.Root class={root()} {...rootProps}>
      <ArkCheckbox.Control class={control()}>
        <ArkCheckbox.Indicator class={indicator()}>
          <CheckIcon />
        </ArkCheckbox.Indicator>
        <ArkCheckbox.Indicator indeterminate class={indicator()}>
          <MinusIcon />
        </ArkCheckbox.Indicator>
      </ArkCheckbox.Control>
      <Show when={getChildren()}>
        <ArkCheckbox.Label class={label()}>{getChildren()}</ArkCheckbox.Label>
      </Show>
    </ArkCheckbox.Root>
```

which is unusable (the checkbox won't check or uncheck).
I figure it was missing the `<ArkCheckbox.HiddenInput />` from the ark documentation.

```
<ArkCheckbox.Root class={root()} {...rootProps}>
      <ArkCheckbox.Control class={control()}>
        <ArkCheckbox.Indicator class={indicator()}>
          <CheckIcon />
        </ArkCheckbox.Indicator>
        <ArkCheckbox.Indicator indeterminate class={indicator()}>
          <MinusIcon />
        </ArkCheckbox.Indicator>
      </ArkCheckbox.Control>
      <Show when={getChildren()}>
        <ArkCheckbox.Label class={label()}>{getChildren()}</ArkCheckbox.Label>
      </Show>
       <ArkCheckbox.HiddenInput />
    </ArkCheckbox.Root>
```