### PR TITLE
fix(website): document missing cli command

### DIFF
--- a/website/src/content/pages/overview/getting-started.mdx
+++ b/website/src/content/pages/overview/getting-started.mdx
@@ -110,13 +110,13 @@ If a `park-ui.json` file is not found in your project, the CLI will prompt you t
 To add multiple components at once, separate their names with spaces:
 
 ```bash
-npx @park-ui/cli add avatar button card
+npx @park-ui/cli components add avatar button card
 ```
 
 To add all available components at once, use the `--all` flag:
 
 ```bash
-npx @park-ui/cli add --all
+npx @park-ui/cli components add --all
 ```
 
 And that's it! Happy hacking! ✌️


### PR DESCRIPTION
- Seems the instructions are missing the cli command

```sh
$ npx @park-ui/cli add button card
park-ui <command>

Commands:
  park-ui components add [components..]  Add components to your project

Options:
  --version  Show version number                                       [boolean]
  --help     Show help                                                 [boolean]

Unknown arguments: add, button, card
```