### PR TITLE
fix `Missing token: colors.red.9`

### DIFF
--- a/packages/panda/src/theme/semantic-tokens/index.ts
+++ b/packages/panda/src/theme/semantic-tokens/index.ts
@@ -37,7 +37,7 @@ export const createSemanticTokens = (options: PresetOptions) => {
         muted: { value: { _light: '{colors.gray.11}', _dark: '{colors.gray.11}' } },
         subtle: { value: { _light: '{colors.gray.10}', _dark: '{colors.gray.10}' } },
         disabled: { value: { _light: '{colors.gray.9}', _dark: '{colors.gray.9}' } },
-        error: { value: { _light: '{colors.red.9}', _dark: '{colors.red.9}' } },
+        error: { value: { _light: '{colors.red.light.9}', _dark: '{colors.red.dark.9}' } },
       },
       border: {
         default: { value: { _light: '{colors.gray.7}', _dark: '{colors.gray.7}' } },
@@ -45,7 +45,7 @@ export const createSemanticTokens = (options: PresetOptions) => {
         subtle: { value: { _light: '{colors.gray.4}', _dark: '{colors.gray.4}' } },
         disabled: { value: { _light: '{colors.gray.5}', _dark: '{colors.gray.5}' } },
         outline: { value: { _light: '{colors.gray.a9}', _dark: '{colors.gray.a9}' } },
-        error: { value: { _light: '{colors.red.9}', _dark: '{colors.red.9}' } },
+        error: { value: { _light: '{colors.red.light.9}', _dark: '{colors.red.dark.9}' } },
       },
     },
     shadows,


### PR DESCRIPTION
I got this error with `@park-ui/panda-preset@0.41.0`

```
🐼 warn [config] ⚠️ Invalid config:
- [tokens] Missing token: `colors.red.9` used in `theme.semanticTokens.colors.fg.error`
- [tokens] Missing token: `colors.red.9` used in `theme.semanticTokens.colors.border.error`
```


Changing the semantic token value from `colors.red.9` to `colors.red.light.9` and `colors.red.dark.9` seems to solve the problem.