### PR TITLE
fix(solid): replace with correct element type

### DIFF
--- a/components/solid/src/components/ui/styled/heading.tsx
+++ b/components/solid/src/components/ui/styled/heading.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps } from 'solid-js'
+import type { ComponentProps, JSXElement } from 'solid-js'
 import { styled } from 'styled-system/jsx'
 import { type TextVariantProps, text } from 'styled-system/recipes'
 import type { StyledComponent } from 'styled-system/types'
 
-type TextProps = TextVariantProps & { as?: React.ElementType }
+type TextProps = TextVariantProps & { as?: JSXElement }
 
 export type HeadingProps = ComponentProps<typeof Heading>
 export const Heading = styled('h2', text, {

--- a/components/solid/src/components/ui/styled/text.tsx
+++ b/components/solid/src/components/ui/styled/text.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps } from 'solid-js'
+import type { ComponentProps, JSXElement } from 'solid-js'
 import { styled } from 'styled-system/jsx'
 import { type TextVariantProps, text } from 'styled-system/recipes'
 import type { StyledComponent } from 'styled-system/types'
 
-type ParagraphProps = TextVariantProps & { as?: JSX.ElementType }
+type ParagraphProps = TextVariantProps & { as?: JSXElement }
 
 export type TextProps = ComponentProps<typeof Text>
 export const Text = styled('p', text) as StyledComponent<'p', ParagraphProps>


### PR DESCRIPTION
These types do not exist in solidjs, replaced them with the correct ones.