### PR TITLE
Allow Switch has outline on focus

### DIFF
--- a/packages/panda/src/theme/recipes/switch.ts
+++ b/packages/panda/src/theme/recipes/switch.ts
@@ -25,6 +25,11 @@ export const switchRecipe = defineSlotRecipe({
       _checked: {
         background: 'colorPalette.default',
       },
+      _focusVisible: {
+        outline: '2px solid',
+        outlineColor: 'colorPalette.default',
+        outlineOffset: '2px',
+      },
     },
     label: {
       color: 'fg.default',


### PR DESCRIPTION
Right now Switch does not have an outline on focus. It's not good from points of accessibility and keyboard navigation.

I add `_focusVisible` styles copied from `button` recipe and it looks good

<img width="534" alt="CleanShot 2024-10-25 at 12 30 44@2x" src="https://github.com/user-attachments/assets/f84d1d1b-f559-4432-9281-ad6bce487894">
