### PR TITLE
Fix Button Loading State Logic (react)

### DIFF
--- a/components/react/src/components/ui/button.tsx
+++ b/components/react/src/components/ui/button.tsx
@@ -17,13 +17,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) =>
 
   return (
     <StyledButton disabled={trulyDisabled} ref={ref} {...rest}>
-      {loading && !loadingText ? (
-        <>
-          <ButtonSpinner />
-          <styled.span opacity={0}>{children}</styled.span>
-        </>
-      ) : loadingText ? (
-        loadingText
+      {loading ? (
+        loadingText ? (
+          loadingText
+        ) : (
+          <>
+            <ButtonSpinner />
+            <styled.span opacity={0}>{children}</styled.span>
+          </>
+        )
       ) : (
         children
       )}


### PR DESCRIPTION
## Description

This PR fixes a logic issue in the Button component where loadingText would always be displayed when provided, regardless of the loading state. The correct behavior is to only show loadingText when the button is in a loading state.

## Changes

Updated the conditional rendering logic in the Button component
The component now correctly:

Shows loadingText if loading=true and loadingText exists
Shows spinner with invisible children if loading=true and no loadingText
Shows children if loading=false, regardless of loadingText value