### PR TITLE
fix(panda-preset): Include `src` files in published artifact

### DIFF
--- a/packages/panda/package.json
+++ b/packages/panda/package.json
@@ -43,7 +43,7 @@
   "main": "src/index.ts",
   "module": "src/index.ts",
   "types": "src/index.ts",
-  "files": ["dist"],
+  "files": ["dist", "src"],
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
In working on issue cschroeter/park-ui#474 I forked and published panda-preset to my own alias to confirm the current state of the `main` branch correctly avoids the "manifest confusion" I noted in my comment. While publishing I noted that I could not work with the package because the files in the `src` directory were not included on publish. Adding src to the `"files"` stanza in package.json fixes this issue.

**Good news** is that after doing this I was able to install my 'fork' aliased as @park-ui/panda-preset in my primary project and it succeeds and fully works as intended, so I can hard confirm just doing a publish bump _after this PR is merged_ will fix install issues for those of us without bun installed.