### PR TITLE
chore: align usage instructions with Ark UI

### DIFF
--- a/website/src/demos/file-upload.demo.tsx
+++ b/website/src/demos/file-upload.demo.tsx
@@ -7,8 +7,8 @@ import { IconButton } from '~/components/ui/icon-button'
 export const Demo = (props: FileUpload.RootProps) => {
   return (
     <FileUpload.Root maxFiles={3} {...props}>
+      <FileUpload.Label>Drop your files here</FileUpload.Label>
       <FileUpload.Dropzone>
-        <FileUpload.Label>Drop your files here</FileUpload.Label>
         <FileUpload.Trigger asChild>
           <Button size="sm">Open Dialog</Button>
         </FileUpload.Trigger>


### PR DESCRIPTION
Clicking the FileUpload.Label area causes the file upload dialog to appear again after selecting a file or canceling. There is a discrepancy in behavior between `Park UI` and `Ark UI` implementations.

https://github.com/user-attachments/assets/e22a7d91-3d62-4537-ae8b-a2fd9304c7eb

**Park UI Implementation**
https://park-ui.com/docs/components/file-upload

```
...
<FileUpload.Dropzone>
  <FileUpload.Label>Drop your files here</FileUpload.Label>
  <FileUpload.Trigger asChild>
    <Button size="sm">Open Dialog</Button>
  </FileUpload.Trigger>
</FileUpload.Dropzone>
...
```

**Ark UI Implementation**
https://ark-ui.com/docs/components/file-upload
```
...
<FileUpload.Label>Drop your files here</FileUpload.Label>
<FileUpload.Dropzone>
  <FileUpload.Trigger asChild>
    <Button size="sm">Open Dialog</Button>
  </FileUpload.Trigger>
</FileUpload.Dropzone>
...
```