### PR TITLE
Add "importing secondary color palettes" to customize docs

### DIFF
--- a/website/src/content/pages/theme/customize.mdx
+++ b/website/src/content/pages/theme/customize.mdx
@@ -126,6 +126,33 @@ export default defineConfig({
 
 > You don't have to use color tokens. You can also use simple color values like `#000` or `black`.
 
+## Importing secondary color palettes
+
+Whilst Park UI will always use a the accent color, you may want to also include another color palette. A common use case for this might be wanting green for success states
+
+```ts
+import { defineConfig } from '@pandacss/dev'
+import green from '@park-ui/panda-preset/colors/green';
+
+export default defineConfig({
+  ...
+  theme: {
+    extend: {
+      tokens: {
+        colors: {
+          green: green.tokens,
+        },
+      },
+      semanticTokens: {
+        colors: {
+          green: green.semanticTokens,
+        }
+      }
+    }
+  }
+ });
+```
+
 ## Recipes  
 
 As of `v0.44`, the `@park-ui/panda-preset` no longer includes component recipes.


### PR DESCRIPTION
## Summary
This pull request adds a new section to the `customize.mdx` documentation page, explaining how to import secondary color palettes in Park UI. The change provides an example of using a green color palette for success states.

## Justification
I think this is a beneficial change due to to the topics found here;
* https://github.com/cschroeter/park-ui/issues/170
* https://github.com/cschroeter/park-ui/issues/278
* https://github.com/cschroeter/park-ui/issues/453
* https://github.com/cschroeter/park-ui/issues/485
* https://github.com/cschroeter/park-ui/issues/508

It is, notably, https://github.com/cschroeter/park-ui/issues/485, which is where this solution comes from. But with the number of issues having it officially in the documentation would be great.

## Alternatives
Of course, if we could tap into the `additionalColors` as resolved by this PR; https://github.com/cschroeter/park-ui/pull/509 that would be far more ideal.

