### PR TITLE
FIXED: Broken references in recipes of accent to colorPalette

### DIFF
--- a/packages/preset/src/theme/recipes/button.ts
+++ b/packages/preset/src/theme/recipes/button.ts
@@ -81,12 +81,12 @@ export const button = defineRecipe({
           outlineOffset: '2px',
         },
         _selected: {
-          background: 'accent.default',
-          borderColor: 'accent.default',
-          color: 'accent.fg',
+          background: 'colorPalette.default',
+          borderColor: 'colorPalette.default',
+          color: 'colorPalette.fg',
           _hover: {
-            background: 'accent.emphasized',
-            borderColor: 'accent.emphasized',
+            background: 'colorPalette.emphasized',
+            borderColor: 'colorPalette.emphasized',
           },
         },
       },

--- a/packages/preset/src/theme/recipes/tree-view.ts
+++ b/packages/preset/src/theme/recipes/tree-view.ts
@@ -51,7 +51,7 @@ export const treeView = defineSlotRecipe({
       },
     },
     branchIndicator: {
-      color: 'accent.default',
+      color: 'colorPalette.default',
       transformOrigin: 'center',
       transitionDuration: 'normal',
       transitionProperty: 'transform',
@@ -92,11 +92,11 @@ export const treeView = defineSlotRecipe({
         color: 'fg.default',
       },
       _selected: {
-        background: 'accent.a2',
-        color: 'accent.text',
+        background: 'colorPalette.a2',
+        color: 'colorPalette.text',
         _hover: {
-          background: 'accent.a2',
-          color: 'accent.text',
+          background: 'colorPalette.a2',
+          color: 'colorPalette.text',
         },
         _before: {
           content: '""',
@@ -105,7 +105,7 @@ export const treeView = defineSlotRecipe({
           top: '0',
           width: '2px',
           height: 'full',
-          bg: 'accent.default',
+          bg: 'colorPalette.default',
           zIndex: '1',
         },
       },


### PR DESCRIPTION
The ParkUI demo site is broken:

![image](https://github.com/user-attachments/assets/073b9683-5e3c-42e0-81dc-d62f6f389b56)

And in addition the ArkUI site itself, but I believe it uses ParkUI for rendering:

![image](https://github.com/user-attachments/assets/18dd908d-2728-4ef0-aa08-86d7403860e0)

It seems to stem from these incorrect references in the recipes of accent instead of colorPalette.