### PR TITLE
fix(cli): support tsconfig without `baseUrl`

### DIFF
--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -64,11 +64,16 @@ const getTsConfigAliasPrefix = (tsConfig: TSConfigSchema): string | null => {
   const paths = tsConfig.compilerOptions.paths
   const commonPaths = ['./*', './src/*', './app/*', './resources/js/*']
 
-  for (const [alias, pathList] of Object.entries(paths)) {
+  // Exclude the "*": ["./*"] catch-all used as a baseUrl replacement for bare imports (e.g. "styled-system"); it is not a user alias.
+  const aliasEntries = Object.entries(paths).filter(
+    ([alias]) => alias !== '*' && alias.endsWith('/*'),
+  )
+
+  for (const [alias, pathList] of aliasEntries) {
     if (pathList.some((p) => commonPaths.includes(p))) {
       return alias.replace(/\/\*$/, '')
     }
   }
 
-  return Object.keys(paths)[0]?.replace(/\/\*$/, '') ?? null
+  return aliasEntries[0]?.[0].replace(/\/\*$/, '') ?? null
 }

--- a/packages/cli/src/utils/tsconfig.ts
+++ b/packages/cli/src/utils/tsconfig.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import * as p from '@clack/prompts'
 import { Context, Effect, Layer, Schema } from 'effect'
 import { parse } from 'tsconfck'
@@ -6,7 +7,7 @@ import { PandaConfig } from './panda-config'
 
 const TSConfigSchema = Schema.Struct({
   compilerOptions: Schema.Struct({
-    baseUrl: Schema.String,
+    baseUrl: Schema.optional(Schema.String),
     paths: Schema.Record({
       key: Schema.String,
       value: Schema.mutable(Schema.Array(Schema.String)),
@@ -29,14 +30,18 @@ const getConfig = PandaConfig.pipe(
       catch: () => TSConfigNotFound(process.cwd()),
     }),
   ),
-  Effect.flatMap((config) => Schema.decodeUnknown(TSConfigSchema)(config.tsconfig)),
-  Effect.flatMap((config) => {
+  Effect.flatMap((parsed) =>
+    Schema.decodeUnknown(TSConfigSchema)(parsed.tsconfig).pipe(
+      Effect.map((config) => ({ config, tsconfigFile: parsed.tsconfigFile })),
+    ),
+  ),
+  Effect.flatMap(({ config, tsconfigFile }) => {
     const aliasPrefix = getTsConfigAliasPrefix(config)
     if (!aliasPrefix) return Effect.fail(TSConfigInvalid())
 
     return Effect.succeed({
       aliasPrefix,
-      baseUrl: config.compilerOptions?.baseUrl || '',
+      baseUrl: config.compilerOptions?.baseUrl ?? path.dirname(tsconfigFile),
       paths: config.compilerOptions?.paths || {},
     })
   }),


### PR DESCRIPTION
## Summary

`@park-ui/cli` currently fails when the user's `tsconfig.json` has no `compilerOptions.baseUrl`. This PR lifts that requirement while preserving full backwards compatibility.

## Context

TypeScript 6.0 (GA) deprecates `baseUrl`; TypeScript 7 removes it (already rejected by `@typescript/native-preview` / `tsgo`). The recommended migration is to drop `baseUrl` and rely on `paths` alone, optionally with `"*": ["./*"]` for bare imports such as `styled-system`.

Refs #549, #540.

## Changes

Two independent commits:

1. **`fix(cli): make tsconfig baseUrl optional`**
   `baseUrl` becomes optional in the schema. When absent, the CLI falls back to `path.dirname(tsconfigFile)`, matching TypeScript's own `paths` resolution behavior (TS 4.1+). Uses `tsconfigFile` already returned by `tsconfck.parse()`; no new dependency.

2. **`fix(cli): ignore "*" catch-all path when detecting alias prefix`**
   With `baseUrl` optional, users commonly add `"*": ["./*"]` for bare imports. The previous `getTsConfigAliasPrefix` picked this catch-all as the alias prefix, producing paths like `*/components` in `components.json`. The detector now ignores `"*"` and any key not ending in `/*`, so only real aliases (`~/*`, `@/*`, …) are considered.

## Backwards compatibility

Projects with `baseUrl` defined behave identically. Only configurations that previously failed now work.

## Test plan

- [x] `bun run build`, `bun run lint`, `bunx tsc --noEmit` in `packages/cli` — no new errors in touched files (pre-existing `magicast/helpers` resolution error in `panda-config.ts` is unrelated to this PR).
- [x] Sandbox A: `baseUrl: "."` + `paths: { "~/*": ["./src/*"] }` → generates into `src/*` (unchanged).
- [x] Sandbox B: no `baseUrl` + `paths: { "*": ["./*"], "~/*": ["./app/*"] }` → generates into `app/*` (previously failed or wrote to `*/theme`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)